### PR TITLE
accept content-type: application/json

### DIFF
--- a/database.js
+++ b/database.js
@@ -118,14 +118,21 @@ app.get('/nodes/:id', adminAuth, function(req, res){
 // create node
 app.post('/nodes', deployerAuth, function(req, res){
     console.log('Creating node');
-    if(!req.body.data) {
-        error(res, "data parameter not set or empty");
-        return;
-    }
-    var data = JSON.parse(req.body.data);
-    if(!data) {
-        error(res, "data parameter is not valid json");
-        return;
+    var data;
+    if(req.headers['content-type'] === 'application/json') {
+        // a JSON POST is acceptable
+        data = req.body;
+    } else {
+        // a url-encoded POST with data=JSON is also acceptable
+        if(!req.body.data) {
+            error(res, "data parameter not set or empty");
+            return;
+        }
+        data = JSON.parse(req.body.data);
+        if(!data) {
+            error(res, "data parameter is not valid json");
+            return;
+        }
     }
     q.createNode(data, function(err, node) {
         if(err) {
@@ -143,14 +150,21 @@ app.put('/nodes/:id', deployerAuth, function(req, res){
         error(res, "node id must be specified in request");
         return;
     }
-    if(!req.body.data) {
-        error(res, "data parameter not set or empty");
-        return;
-    }
-    var data = JSON.parse(req.body.data);
-    if(!data) {
-        error(res, "data parameter is not valid json");
-        return;
+    var data;
+    if(req.headers['content-type'] === 'application/json') {
+        // a JSON POST is acceptable
+        data = req.body;
+    } else {
+        // a url-encoded POST with data=JSON is also acceptable
+        if(!req.body.data) {
+            error(res, "data parameter not set or empty");
+            return;
+        }
+        data = JSON.parse(req.body.data);
+        if(!data) {
+            error(res, "data parameter is not valid json");
+            return;
+        }
     }
     q.updateNode(data, function(err, node) {
         if(err) {


### PR DESCRIPTION
extend POST /nodes and PUT /nodes/:id to accept content-type: application/json

sticking json in the data param of an x-www-form-urlencoded request still works too, but accepting json in a json request seemed more obvious to me

before this PR, the curl command to create a node was:

```
curl -X POST -H "Content-Type: application/x-www-form-urlencoded" --data-urlencode data='{"type":"node"}' http://<user>:<password>@localhost:3000/nodes
```

after this PR, the above command still works, and so does:

```
curl -X POST -H "Content-Type: application/json" --data '{"type":"node"}' http://<user>:<password>@localhost:3000/nodes
```
